### PR TITLE
cli/base: Use more universally readable colors

### DIFF
--- a/ppci/cli/base.py
+++ b/ppci/cli/base.py
@@ -125,7 +125,9 @@ class ColoredFormatter(logging.Formatter):
     """ Custom formatter that makes vt100 coloring to log messages """
 
     BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
-    colors = {"WARNING": YELLOW, "ERROR": RED}
+    # Before changing colors, consider that they must be legible on
+    # (at least) both white-on-black and black-on-white terminal themes.
+    colors = {"WARNING": MAGENTA, "ERROR": RED}
 
     def format(self, record):
         reset_seq = "\033[0m"

--- a/ppci/cli/base.py
+++ b/ppci/cli/base.py
@@ -125,7 +125,7 @@ class ColoredFormatter(logging.Formatter):
     """ Custom formatter that makes vt100 coloring to log messages """
 
     BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
-    colors = {"INFO": WHITE, "WARNING": YELLOW, "ERROR": RED}
+    colors = {"WARNING": YELLOW, "ERROR": RED}
 
     def format(self, record):
         reset_seq = "\033[0m"


### PR DESCRIPTION
Don't assume white-on-black terminal setup. Different OSes and distros
may have a different terminal color themes. E.g. Ubuntu, a pretty popular
Linux distro, by default comes with black-on-white theme. So, using
explicit black or white foreground color may lead to completely
unreadable output. Instead, just use the default terminal color for
normal messages.