### PR TITLE
[docs] fix tutorial errors

### DIFF
--- a/docs/howto/toy.rst
+++ b/docs/howto/toy.rst
@@ -115,7 +115,7 @@ code later on.
 
     from ppci import ir
     ir_module = ir.Module('toy')
-    ir_function = ir.Procedure('toy')
+    ir_function = ir.Procedure('toy', ir.Binding.GLOBAL)
     ir_module.add_function(ir_function)
     ir_block = ir.Block('entry')
     ir_function.entry = ir_block
@@ -146,6 +146,8 @@ x86_64, but you could as well use AVR or riscv here.
 
 .. code:: python
 
+    from ppci.irutils import Verifier
+    from ppci import api
     Verifier().verify(ir_module)
     obj1 = api.ir_to_object([ir_module], 'x86_64')
     obj = api.link([obj1])


### PR DESCRIPTION
[**Creating a toy language tutorial**](https://ppci.readthedocs.io/en/latest/howto/toy.html)
**[Part 2 - connecting the backend](https://ppci.readthedocs.io/en/latest/howto/toy.html#part-2-connecting-the-backend)**

the Procedure method needs an additional argument 'binding'

Old code
`ir_module = ir.Module('toy')`
`ir_function = ir.Procedure('toy')`
New code
`ir_module = ir.Module('toy')`
`ir_function = ir.Procedure('toy', ir.Binding.GLOBAL)`

and this code snippet need imports of Verifier and API to be run correctly
Old code
```
Verifier().verify(ir_module)
obj1 = api.ir_to_object([ir_module], 'x86_64')
obj = api.link([obj1])
print(obj)
```
New code
```
from ppci.irutils import Verifier
from ppci import api
Verifier().verify(ir_module)
obj1 = api.ir_to_object([ir_module], 'x86_64')
obj = api.link([obj1])
print(obj)
```
