### PR TITLE
examples/linux64: Add example of interoperability with a host compiler.

### DIFF
--- a/examples/linux64/gcc-interop/Makefile
+++ b/examples/linux64/gcc-interop/Makefile
@@ -1,0 +1,19 @@
+all: interop
+
+# Now link all compiled objects (here, just one) into executable. For this,
+# we need to provide linker with memory layout file. We'll also use main()
+# as the executable entrypoint.
+interop: ppci_part.o gcc_part.o
+	$(CC) $^ -o $@
+
+gcc_part.o: gcc_part.c
+	$(CC) $(CFLAGS) -c $^ -o $@
+
+ppci_part.o: ppci_part.jso
+	python -m ppci objcopy --output-format elf $^ $@
+
+ppci_part.jso: ppci_part.c
+	python -m ppci cc $(CFLAGS) -c $^ -o $@
+
+clean:
+	rm -f *.o hello

--- a/examples/linux64/gcc-interop/README.md
+++ b/examples/linux64/gcc-interop/README.md
@@ -1,0 +1,15 @@
+# gcc-interop
+
+This example shows interoperability with a host compiler (the example
+name talks about GCC, but it should work with any other full-fledged
+host compiler, the only requirement is that is able to process ELF
+object files).
+
+The idea is to compile some source files with PPCI (this example uses
+C source files, but it can be any other language supported by PPCI),
+while other source files - with the host compiler, and perform final
+link with the host compiler too. This enables a number of useful
+scenarios not yet supported natively by PPCI:
+
+* Accessing functions in the C standard library and other libraries.
+* Supporting dynamic linking.

--- a/examples/linux64/gcc-interop/gcc_part.c
+++ b/examples/linux64/gcc-interop/gcc_part.c
@@ -1,0 +1,8 @@
+int ppci_func(void);
+
+const char msg[] = "Hello from both sides!\n";
+
+int main()
+{
+    ppci_func();
+}

--- a/examples/linux64/gcc-interop/ppci_part.c
+++ b/examples/linux64/gcc-interop/ppci_part.c
@@ -1,0 +1,14 @@
+/* Will call external function. */
+int printf(const char *s, ...);
+
+/* Will access external data symbol. */
+extern const char msg[];
+
+/* Put external symbol in an array, to make sure that relocations for data
+   section are properly generated. */
+const char *msg_arr[] = {msg};
+
+int ppci_func(void) {
+    printf(msg);
+    printf(msg_arr[0]);
+}


### PR DESCRIPTION
Called "gcc-interop" for conciseness, it's not limited to GCC. The idea
is to compile PPCI source to PPCI native objects (JSON), convert to ELF
objects, and then use a host compiler (like GCC) for final link.

Signed-off-by: Paul Sokolovsky <pfalcon@users.sourceforge.net>